### PR TITLE
Sarbuck patch 1

### DIFF
--- a/pcm_calculateG.m
+++ b/pcm_calculateG.m
@@ -1,5 +1,5 @@
 function [G,dGdtheta] = pcm_calculateG(M,theta,G_hat)
-% function [G,dGdtheta] = pcm_calculateG(M,theta)
+% function [G,dGdtheta] = pcm_calculateG(M,theta,G_hat)
 % This function calculates the predicted second moment matrix (G) and the
 % derivate of the second moment matrix in respect to the parameters theta. 
 % INPUT: 

--- a/pcm_calculateG.m
+++ b/pcm_calculateG.m
@@ -1,10 +1,11 @@
-function [G,dGdtheta] = pcm_calculateG(M,theta)
+function [G,dGdtheta] = pcm_calculateG(M,theta,G_hat)
 % function [G,dGdtheta] = pcm_calculateG(M,theta)
 % This function calculates the predicted second moment matrix (G) and the
 % derivate of the second moment matrix in respect to the parameters theta. 
 % INPUT: 
 %       M:        Model structure 
 %       theta:    Vector of parameters 
+%       G_hat:    Crossvalidated second moment matrix for subject
 % OUTPUT: 
 %       G:        Second moment matrix 
 %       dGdtheta: Matrix derivatives in respect to parameters 
@@ -36,5 +37,8 @@ else
             end;                 
         case 'nonlinear'
             [G,dGdtheta]=M.modelpred(theta(1:M.numGparams));
+        case 'noiseceiling'
+            G = M.modelpred(G_hat);
+            dGdtheta = [];
     end;
 end;

--- a/pcm_getStartingval.m
+++ b/pcm_getStartingval.m
@@ -9,7 +9,7 @@ function theta0 = pcm_getStartingval(M,G_hat)
 %       theta0:     vector of model parameters 
 
 switch (M.type) 
-    case 'fixed' 
+    case 'fixed'
         theta0=[]; 
     case 'component' 
         for i=1:size(M.Gc,3)
@@ -23,5 +23,7 @@ switch (M.type)
         error('not implemented yet'); 
     case 'nonlinear' 
         error('cannot provide starting values for nonlinear models'); 
+    case 'noiseceiling'
+        theta0 = M.theta0;
 end; 
         

--- a/pcm_getStartingval.m
+++ b/pcm_getStartingval.m
@@ -24,6 +24,10 @@ switch (M.type)
     case 'nonlinear' 
         error('cannot provide starting values for nonlinear models'); 
     case 'noiseceiling'
-        theta0 = M.theta0;
+        if ~(isempty(M.theta))
+            theta0 = M.theta0;
+        else
+            theta0 = [];
+        end
 end; 
         


### PR DESCRIPTION
Added functionality to pcm_fitModelCrossval to accept 'noiseceiling' type models. 

Three functions edited:
pcm_fitModelCrossval
pcm_calculateG
pcm_getStartingval

Edits allow for calculation of noiseceiling G predictions with minimal alteration to current overall structure. Added cases for noiseceiling in calculateG and getStartingval. The case added to getStartingval was included to avoid errors- there is no need for starting values when modelling noise ceiling, and so function returns theta values that are defined in the noiseceiling case in model structure M. 

There is one alteration to the frame of the toolbox- submitting G_hat of each subject to pcm_calculateG. 

See files for comments about certain edits.
