### PR TITLE
Fixed Model Handling

### DIFF
--- a/pcm_calculateG.m
+++ b/pcm_calculateG.m
@@ -22,7 +22,7 @@ else
     end;
     switch (M.type)
         case {'fixed','noiseceiling'}
-            G=M.Gc;
+            G        = mean(M.Gc,3);
             dGdtheta =[]; 
         case 'component'
             dGdtheta=bsxfun(@times,M.Gc,permute(exp(theta),[3 2 1]));


### PR DESCRIPTION
Adjusted line 25 to handle fixed models with unique fixed G for each subject.
Since pcm_calculateG is only ever called for overall fitting (never for crossval fitting) for fixed models, we can average across all subjects' Gs.