### PR TITLE
Fixed Model Handling

### DIFF
--- a/pcm_calculateG.m
+++ b/pcm_calculateG.m
@@ -22,7 +22,7 @@ else
     end;
     switch (M.type)
         case {'fixed','noiseceiling'}
-            G=M.Gc;
+            G        = mean(M.Gc,3);
             dGdtheta =[]; 
         case 'component'
             dGdtheta=bsxfun(@times,M.Gc,permute(exp(theta),[3 2 1]));

--- a/pcm_fitModelCrossval.m
+++ b/pcm_fitModelCrossval.m
@@ -216,7 +216,11 @@ for s = 1:numSubj
         % Now fit to all the subject but the left-out one
         switch (M{m}.type)
             case 'fixed'
-                G = M{m}.Gc;
+                if size(M{m}.Gc,3)>1
+                    G = mean(M{m}.Gc(:,:,notS),3);
+                else
+                    G = M{m}.Gc;
+                end
                 i = 0;
             case 'noiseceiling'
                 G = mean(G_hat(:,:,notS),3);    % uses the mean of all other subjects


### PR DESCRIPTION
Edited pcm_calculateG and pcm_fitModelCrossval to allow for fixed models that have unique G for every subject (i.e. predicted G under fixed model for each subject prior to calling pcm_fitModelCrossval). In current form, fixed models result in identical group and crossvalidated fits- there is no crossval. Unless I'm missing something, fixed models should always have a predicted G for each subject. However, the proposed edits still facilitate single Gs for fixed models.

For example, let's say we submit a fixed model structure, M. Under this fixed model, we have a unique predicted G for each subject  that we do not want to iterate to achieve the best fit (e.g. do a subject's (co)variances between finger patterns scale as a function of the number of finger presses?). In this structure, M.Gc is a 3 dimensional matrix, where the third dimension contains a G for each subject. The current versions of pcm_calculateG and fitModelCrossval do not support fixed G for each subject under the same fixed model. The two edits proposed allow for this support. Importantly, they do not adjust current functionality, but rather just expand functionality. 